### PR TITLE
Bug/invalid torrent state labels

### DIFF
--- a/mock_backend/sample_data.js
+++ b/mock_backend/sample_data.js
@@ -15,7 +15,7 @@ const MAX_ETA_SIZE = 28800; // 8 hours
 // Some possible states a torrent can be in
 const torrent_states = [
   'forcedUP', 'error', 'pausedUP', 'pausedDL', 'queuedUP', 'uploading',
-  'stalledUP', 'downloading', 'stalledDL'
+  'stalledUP', 'downloading', 'stalledDL', 'moving'
 ];
 
 var RID = -1;    // For /sync/maindata endpoint

--- a/src/app/services/pretty-print-torrent-data.service.ts
+++ b/src/app/services/pretty-print-torrent-data.service.ts
@@ -22,21 +22,24 @@ export class PrettyPrintTorrentDataService {
   pretty_print_status(status: string): string {
     let statusMapping = {
       forcedUP: "Seeding",
+      forceDL: "Downloading",
       error: "Error",
       pausedUP :"Paused",
       pausedDL: "Paused",
       queuedUP: "Queued",
       queuedDL: "Queued",
       uploading: "Seeding",
-      stalledUP: "Stalled",
-      stalledDL: "Stalled",
+      stalledUP: "Seeding",
+      stalledDL: "Seeding",
       checkingUP: "Loading...",
       checkingDL: "Loading...",
       downloading: "Downloading",
+      moving: 'Moving',
       metaDL: "Loading...",
+      missingFiles: "Missing!"
     }
 
-    return statusMapping[status] || "UNKNOWN";
+    return statusMapping[status] || "Unknown";
   }
 
   pretty_print_file_size(size: number): string {

--- a/src/app/torrents-table/torrents-table.component.html
+++ b/src/app/torrents-table/torrents-table.component.html
@@ -64,7 +64,7 @@
 
           <div *ngSwitchCase="'Status'">
             <mat-chip-list>
-              <mat-chip color="{{torrent.state === 'downloading' ? 'primary' : isTorrentError(torrent) ? 'accent':'default'}}" disableRipple selected>
+              <mat-chip color="{{isTorrentPrimaryAction(torrent) ? 'primary' : isTorrentError(torrent) ? 'accent' : 'default'}}" disableRipple selected>
                 {{torrent.force_start ? '[F]' : ''}} {{getStatusString(torrent.state)}}
               </mat-chip>
             </mat-chip-list>
@@ -77,7 +77,7 @@
           <div *ngSwitchCase="'Uploaded'">
             {{getFileSizeString(torrent.uploaded)}}
           </div>
-          
+
           <div *ngSwitchCase="'Ratio'">
             {{getTorrentRatioString(torrent)}}
           </div>

--- a/src/app/torrents-table/torrents-table.component.ts
+++ b/src/app/torrents-table/torrents-table.component.ts
@@ -363,9 +363,14 @@ export class TorrentsTableComponent implements OnInit {
     this.onMatSortChange(this.currentMatSort);
   }
 
+  public isTorrentPrimaryAction(tor: Torrent): boolean {
+    let actions = ['downloading', 'moving'];
+    return actions.includes(tor.state);
+  }
+
   /** Determine if torrent is in a error state */
   public isTorrentError(tor: Torrent): boolean {
-    let errors = ['error', 'stalledUP', 'stalledDL', 'unknown'];
+    let errors = ['missingFiles', 'error', 'unknown'];
     return errors.includes(tor.state);
   }
 


### PR DESCRIPTION
Fix labels for when torrents are seeding/moving, and some other scenarios as well.

Resolves #100.